### PR TITLE
Set default value as None for category__gn_description field

### DIFF
--- a/src/hdx/scraper/geonode/geonodetohdx.py
+++ b/src/hdx/scraper/geonode/geonodetohdx.py
@@ -299,7 +299,7 @@ class GeoNodeToHDX:
         dataset.add_country_location(countryiso)
         tags = dataset_tags_mapping.get(slugified_name, list())
         tags.append("geodata")
-        tag = layer["category__gn_description"]
+        tag = layer.get("category__gn_description", None)
         if tag is not None:
             if tag in self.category_mapping:
                 tag = self.category_mapping[tag]


### PR DESCRIPTION
This commit fixes the following error:

```
  File "/scripts/hdx-scraper-wfp-geonode/venv/lib64/python3.6/site-packages/hdx/scraper/geonode/geonodetohdx.py", line 302, in generate_dataset_and_showcase
    tag = layer["category__gn_description"]
KeyError: 'category__gn_description'
```